### PR TITLE
Update sim.cu

### DIFF
--- a/src/sim.cu
+++ b/src/sim.cu
@@ -1552,7 +1552,7 @@ void Simulation::wait(double t) {
 }
 
 void Simulation::waitUntil(double t) {
-    if (ENDED) {
+    if (ENDED && !FREED) {
         throw std::runtime_error("The simulation has ended. Control functions cannot be called.");
     }
 


### PR DESCRIPTION
Line 1554 add additional condition to detect if `sim.stop()` has been called. This removes the run_time error when `sim.stop` is called.